### PR TITLE
LDAP round2 (posix data support)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ BASE_IMAGE := user-mutator
 REGISTRY := containers.renci.org/helxplatform
 IMAGE_TAG := $(REGISTRY)/$(BASE_IMAGE)
 CHART_NAME := $(BASE_IMAGE)
-VERSION := $(or $(VERSION),"v1.2.0")
+VERSION := $(or $(VERSION),"v1.3.0")
 
 ## Kind Related
 KIND_CLUSTER := mutator

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.0
+version: 1.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.2.0
+version: 1.2.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.2.0"
+appVersion: "1.3.0"

--- a/chart/templates/configmap.yaml
+++ b/chart/templates/configmap.yaml
@@ -34,8 +34,8 @@ metadata:
 data:
   libnss-ldap.conf: |
     uri ldap://{{ .Values.config.features.ldap.host }}{{if .Values.config.features.ldap.port }}:{{ .Values.config.features.ldap.port }}{{ end }}
-    base {{ .Values.config.features.ldap.base_dn }}
-    nss_base_group ou=groups,dc=example,dc=org
+    base {{ .Values.config.features.ldap.user_base_dn }}
+    nss_base_group {{ .Values.config.features.ldap.group_base_dn }}
     ldap_version 3
     ssl off
     pam_password md5

--- a/chart/templates/configmap.yaml
+++ b/chart/templates/configmap.yaml
@@ -3,11 +3,44 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "user-mutator.fullname" . }}-config
+  labels:
+    app: {{ include "user-mutator.name" . }}
+    chart: {{ include "user-mutator.chart" . }}
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
 data:
   config.json: |
     {
+      "meta": { 
+        {{- if .Values.config.features.ldap }}
+        "libnss_ldap_config_map_name": "{{ include "user-mutator.fullname" . }}-libnss-ldap-config"
+        {{- end }}
+      },
       "features": {{ toPrettyJson .Values.config.features | nindent 8 }},
       "maps": {{ toPrettyJson .Values.config.maps | nindent 8 }},
       "secrets": {{ toPrettyJson .Values.config.secrets | nindent 8 }}
     }
+{{- if .Values.config.features.ldap }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "user-mutator.fullname" . }}-libnss-ldap-config
+  labels:
+    app: {{ include "user-mutator.name" . }}
+    chart: {{ include "user-mutator.chart" . }}
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+data:
+  libnss-ldap.conf: |
+    uri ldap://{{ .Values.config.features.ldap.host }}{{if .Values.config.features.ldap.port }}:{{ .Values.config.features.ldap.port }}{{ end }}
+    base {{ .Values.config.features.ldap.base_dn }}
+    nss_base_group ou=groups,dc=example,dc=org
+    ldap_version 3
+    ssl off
+    pam_password md5
+  nsswitch.conf: |
+    passwd:         files ldap
+    group:          files ldap
+{{- end }}
 {{- end }}

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -31,7 +31,7 @@ spec:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default (printf "v%s" .Chart.AppVersion) }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: http

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -8,7 +8,7 @@ image:
   repository: containers.renci.org/helxplatform/user-mutator
   pullPolicy: Always
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "latest"
+  tag:
 
 imagePullSecrets: []
 nameOverride: ""

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -93,11 +93,13 @@ affinity: {}
 #
 #  features:
 #    ldap:
-#      host: "ldap.example.com"
+#      host: "ldap.example.org"
 #      port: 389
-#      username: "admin"
+#      username: "cn=admin,dc=example,dc=org"
+#      base_dn: "ou=users,dc=example,dc=org"
 #  secrets:
-#    ldapPassword: <ldappw>
+#    ldap-password: <ldapSecret>
+
 
 config:
   enabled: true

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -96,7 +96,8 @@ affinity: {}
 #      host: "ldap.example.org"
 #      port: 389
 #      username: "cn=admin,dc=example,dc=org"
-#      base_dn: "ou=users,dc=example,dc=org"
+#      user_base_dn: "ou=users,dc=example,dc=org"
+#      group_base_dn: "ou=groups,dc=example,dc=org"
 #  secrets:
 #    ldap-password: <ldapSecret>
 

--- a/config.env
+++ b/config.env
@@ -1,4 +1,4 @@
-VERSION=v1.2.0
+VERSION=v1.3.0
 ORGANIZATION=RENCI
 SECRET=user-mutator-cert-tls
 MUTATE_CONFIG=mutating-webhook

--- a/webhook-server/main.go
+++ b/webhook-server/main.go
@@ -915,7 +915,7 @@ func constructSecurityContexts(user *User) (*corev1.PodSecurityContext, *corev1.
 	if securityContext.Capabilities == nil {
 		securityContext.Capabilities = &corev1.Capabilities{}
 	}
-	securityContext.Capabilities.Add = append(securityContext.Capabilities.Add, corev1.Capability("CHOWN"))
+	//securityContext.Capabilities.Add = append(securityContext.Capabilities.Add, corev1.Capability("CHOWN"))
 
 	return &podSecurityContext, &securityContext, nil
 }


### PR DESCRIPTION
Scan LDAP for `posixAccount` and `posixGroup` information to obtain user and group information to modify KubernetesSC. 

- Under the conditions that LDAP defines both kubernetesSC data and posixData are defined, kubernetesSC data takes precedence.
- `SupplementalGroups` is constructed from merging `posixGroups` gid and explicit kubernetesSC `SupplementalGroups`.
- Support the function of libnss-ldap by mounting configmaps to files `/etc/libnss-ldap.conf` and `/etc/nsswitch.conf` to point unix name resolution to ldap.
- Updates helm deploy to construct source configmaps.