### PR TITLE
invert the lookup of ldap files in nsswitch.conf

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.5.1
+version: 1.5.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/chart/templates/configmap.yaml
+++ b/chart/templates/configmap.yaml
@@ -40,7 +40,7 @@ data:
     ssl off
     pam_password md5
   nsswitch.conf: |
-    passwd:         files ldap
-    group:          files ldap
+    passwd:         ldap files
+    group:          ldap files
 {{- end }}
 {{- end }}


### PR DESCRIPTION
Modification of the user-mutator helm chart; the configmap it creates contains `nsswitch.conf` that controls the order in which **ent** elements are retrieved.  Change it from **files ldap** to **ldap files** to shadow invalid entries injected by openshift that otherwise shadow the right entry.