### PR TITLE
Multiple improvements to MutatingWebhookConfiguration, README, and Makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 webhook-server/user-mutator
 *.tgz
-*.pem
-*.crt
+**/*.pem
+**/*.crt
 certs
 venv
 .vscode

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ venv
 .vscode
 tools/selfsigned_cluster_issuer.yaml
 tools/*-mutating-webhook-configuration.yaml
+envs/

--- a/Makefile
+++ b/Makefile
@@ -105,9 +105,7 @@ clean:
 
 deploy-webhook-server: key-cert-secret
 	helm -n $(WEBHOOK_NAMESPACE) upgrade --install $(CHART_NAME) \
-	    --set "image.pullPolicy=IfNotPresent" --set "image.tag=$(VERSION)" \
-		--set "config.secrets.cert=$(SECRET)" $(HELM_INSTALL_ARG_1) $(HELM_INSTALL_ARG_2) \
-		./chart
+	    --values $(VALUES_FILE) ./chart
 	@echo ""
 	@echo "To view and follow the logs of the mutator use the following command."
 	@echo "  kubectl -n $(WEBHOOK_NAMESPACE) -l app.kubernetes.io/name=user-mutator logs -f"

--- a/Makefile
+++ b/Makefile
@@ -104,8 +104,15 @@ clean:
 	rm -f webhook-server/$(BINARY_NAME)
 
 deploy-webhook-server: key-cert-secret
+ifneq ($(strip $(VALUES_FILE)),)
 	helm -n $(WEBHOOK_NAMESPACE) upgrade --install $(CHART_NAME) \
 	    --values $(VALUES_FILE) ./chart
+else
+	helm -n $(WEBHOOK_NAMESPACE) upgrade --install $(CHART_NAME) \
+	    --set "image.pullPolicy=IfNotPresent" --set "image.tag=$(VERSION)" \
+		--set "config.secrets.cert=$(SECRET)" $(HELM_INSTALL_ARG_1) $(HELM_INSTALL_ARG_2) \
+		./chart
+endif
 	@echo ""
 	@echo "To view and follow the logs of the mutator use the following command."
 	@echo "  kubectl -n $(WEBHOOK_NAMESPACE) -l app.kubernetes.io/name=user-mutator logs -f"

--- a/README.md
+++ b/README.md
@@ -1,42 +1,74 @@
-# Mutating Controller for Kubernetes Deployments with for user specialization
+# User-Mutator
 
-### Overview of Functionalities
+The user-mutator will intercept the creation of deployment resources and mutate them in ways defined in the configmap that it's settings are retrieved from.
 
-This collection of functions facilitates a comprehensive system for managing and 
-processing Kubernetes volume configurations and admission control requests in a 
-cloud-native environment. The goal is to streamline the configuration and 
-extension of Kubernetes resources, focusing on volume management and admission 
-control.
+To deploy a very basic user-mutator which adds the proxy environment variables to deployments you can do the following.  This example is for the eduhelx-staging namespace.
 
-#### Key Functionalities:
+The user-mutator can also add volumes to be mounted in pods.  There are YAMLs for this setup in the yamls directory.  eduhelx-data720 and eduhelx-chip690 are examples of adding volumes to pods.
 
-1. **Dynamic Volume Configuration**: Functions like `ReadUserFeaturesFromFile`, 
-`GetK8sVolumes`, `GetK8sVolumeMounts`, and `parseVolumeSource` allow for dynamic 
-and flexible configuration of Kubernetes volumes. They enable reading custom 
-volume configurations from files and transforming these into Kubernetes-native 
-objects (`corev1.Volume` and `corev1.VolumeMount`).
+## Clone the user-mutator github Repo
+```
+git clone https://github.com/helxplatform/user-mutator.git
+```
+Make sure you are on the 'master' branch.
+```
+git checkout master
+```
 
-2. **Admission Control Management**: Functions such as `handleAdmissionReview` and 
-`processAdmissionReview` provide robust mechanisms for Kubernetes admission 
-control. They handle HTTP requests, process these requests to apply custom logic, 
-and generate appropriate responses, ensuring resources are managed according to 
-predefined rules.
+## Create Secret for Proxy Credentials
+Create secret that is used for adding environment variables to pods.  The secret needs to be encoded if there are any characters that need to be escaped (like in the proxy user's password).  This can be done in different ways.
 
-3. **Debugging and Logging Support**: Utility functions like `prettyPrintJSON`, 
-`printVolumes`, `printVolumeMounts`, and `printPatchOperations` provide extensive 
-debugging and logging support. These functions allow for clear logging of complex 
-structures like volumes and JSON patches.
+### Use Browser's Developer Console
+Use encodeURIComponent('password') in developer console of web browser to encode the password if there are symbols.
 
-4. **Patch Calculation for Resource Modification**: The `calculatePatch` function 
-dynamically generates patches for Kubernetes resources, calculating differences 
-between original and modified deployments.
+### Use node.js script at tools/encoder.js
+You need to have node.js installed.  The script will prompt you for what text to encode.
+```
+cd tools
+./encoder.js
+```
 
-5. **Service Readiness Probing**: The `readinessHandler` function provides a 
-mechanism to check the readiness of the service, ensuring it can handle requests 
-effectively.
+### Create the Secret
+```
+NAMESPACE=[NAMESPACE TO DEPLOY USER_MUTATOR IN]
+kubectl -n $NAMESPACE apply -f yamls/proxycreds-env-secret.yaml
+```
 
-Collectively, these functions form a cohesive system that enhances Kubernetes' 
-capabilities, focusing on flexible volume management, streamlined admission 
-control processes, and effective debugging and monitoring tools. This system is 
-beneficial in environments where custom resource configurations and dynamic 
-resource management are critical.
+## Create user-profiles Configmap for User-Mutator
+Create configmap that is used for the user-mutator configuration for the namespace.
+```
+kubectl -n $NAMESPACE apply -f yamls/user-profiles-configmap.yaml
+```
+
+## Create New Environment File for the Namespace
+Copy the config.env from the root of user-mutator source tree into ./envs and add namespace as suffix.
+```
+cp user-mutator/config.env ./envs/config-[NAMESPACE].env
+```
+Set these variables appropriately (change namespace name).
+  - MUTATE_CONFIG=mutating-webhook-eduhelx-staging
+  - WEBHOOK_NAMESPACE=eduhelx-staging
+  - NAMESPACE_TO_MUTATE=eduhelx-staging
+Remove or comment out the line with "VERSION" (unless you know you need to use a certain version).
+
+## Deploy the User-Mutator to the Namespace
+Change your current working directory to the root of the user-mutator code.
+```
+cd user-mutator
+```
+
+## Use the Makefile to Deploy the User-Mutator
+```
+make cnf=../envs/config-eduhelx-staging.env deploy-all
+```
+
+## Enable the User-Mutator to Run on objects created in the namespace.
+For the User-Mutator to examine new objects in the namespace the namespace needs to have a label that enables it.
+```
+make cnf=../envs/config-eduhelx-staging.env enable-mutate-in-namespace
+```
+
+## Renew Certs when they Expire
+```
+make cnf=../envs/config-eduhelx-staging.env regenerate-ca-cert-key-and-update-cluster
+```

--- a/config.env
+++ b/config.env
@@ -1,4 +1,4 @@
-VALUES_FILE=../../path/from/chart/dir
+VALUES_FILE=../path/from/root/dir
 VERSION=v1.7.2
 ORGANIZATION=RENCI
 SECRET=user-mutator-cert-tls

--- a/config.env
+++ b/config.env
@@ -1,7 +1,6 @@
-VERSION=v1.7.2
 ORGANIZATION=RENCI
 SECRET=user-mutator-cert-tls
-MUTATE_CONFIG=mutating-webhook
+MUTATE_CONFIG=user-mutator-webhook-ai-sb-test
 WEBHOOK_SERVICE=user-mutator
-WEBHOOK_NAMESPACE="default"
-NAMESPACE_TO_MUTATE="default"
+WEBHOOK_NAMESPACE=ai-sb-test
+NAMESPACE_TO_MUTATE=ai-sb-test

--- a/config.env
+++ b/config.env
@@ -1,3 +1,5 @@
+VALUES_FILE=../../path/from/chart/dir
+VERSION=v1.7.2
 ORGANIZATION=RENCI
 SECRET=user-mutator-cert-tls
 MUTATE_CONFIG=user-mutator-webhook

--- a/config.env
+++ b/config.env
@@ -1,6 +1,6 @@
 ORGANIZATION=RENCI
 SECRET=user-mutator-cert-tls
-MUTATE_CONFIG=user-mutator-webhook-ai-sb-test
+MUTATE_CONFIG=user-mutator-webhook
 WEBHOOK_SERVICE=user-mutator
-WEBHOOK_NAMESPACE=ai-sb-test
-NAMESPACE_TO_MUTATE=ai-sb-test
+WEBHOOK_NAMESPACE=example
+NAMESPACE_TO_MUTATE=example

--- a/tls-and-mwc/createMutationConfig.go
+++ b/tls-and-mwc/createMutationConfig.go
@@ -7,6 +7,7 @@ import (
 	"os"
 
 	v1 "k8s.io/api/admissionregistration/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -15,9 +16,10 @@ import (
 func CreateMutationConfig(ctx context.Context, caPEM *bytes.Buffer) {
 
 	var (
-		webhookNamespace = os.Getenv("WEBHOOK_NAMESPACE")
-		mutationCfgName  = os.Getenv("MUTATE_CONFIG")
-		webhookService   = os.Getenv("WEBHOOK_SERVICE")
+		webhookNamespace  = os.Getenv("WEBHOOK_NAMESPACE")
+		mutationCfgName   = os.Getenv("MUTATE_CONFIG")
+		webhookService    = os.Getenv("WEBHOOK_SERVICE")
+		namespaceToMutate = os.Getenv("NAMESPACE_TO_MUTATE")
 	)
 	config := ctrl.GetConfigOrDie()
 	kubeClient, err := kubernetes.NewForConfig(config)
@@ -30,20 +32,21 @@ func CreateMutationConfig(ctx context.Context, caPEM *bytes.Buffer) {
 	fail := v1.Ignore
 	port := int32(8443)
 
-	if err != nil {
-		panic("failed to read certPath")
-	}
-
 	log.Println("WEBHOOK_NAMESPACE: ", webhookNamespace)
 	log.Println("MUTATE_CONFIG: ", mutationCfgName)
 	log.Println("WEBHOOK_SERVICE: ", webhookService)
+	log.Println("NAMESPACE_TO_MUTATE: ", namespaceToMutate)
+
+	if namespaceToMutate == "" {
+		panic("NAMESPACE_TO_MUTATE must be set")
+	}
 
 	mutateconfig := &v1.MutatingWebhookConfiguration{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: mutationCfgName,
 		},
 		Webhooks: []v1.MutatingWebhook{{
-			Name: webhookService+"."+webhookNamespace+".svc",
+			Name: webhookService + "." + webhookNamespace + ".svc",
 			ClientConfig: v1.WebhookClientConfig{
 				CABundle: caPEM.Bytes(), // CA bundle created in generateTLSCerts command
 				Service: &v1.ServiceReference{
@@ -63,13 +66,21 @@ func CreateMutationConfig(ctx context.Context, caPEM *bytes.Buffer) {
 						APIVersions: []string{"v1"},
 						Resources:   []string{"deployments"},
 					},
-				}},
-				NamespaceSelector: &metav1.LabelSelector{
-					MatchLabels: map[string]string{
-							"enable-"+mutationCfgName: "true",
+				},
+			},
+			NamespaceSelector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"enable-" + mutationCfgName: "true",
+				},
+				MatchExpressions: []metav1.LabelSelectorRequirement{
+					{
+						Key:      "kubernetes.io/metadata.name",
+						Operator: metav1.LabelSelectorOpIn,
+						Values:   []string{namespaceToMutate},
 					},
 				},
-				AdmissionReviewVersions: []string{"v1"},
+			},
+			AdmissionReviewVersions: []string{"v1"},
 			FailurePolicy:           &fail,
 			SideEffects: func() *v1.SideEffectClass {
 				sideEffect := v1.SideEffectClassNone
@@ -78,9 +89,29 @@ func CreateMutationConfig(ctx context.Context, caPEM *bytes.Buffer) {
 		}},
 	}
 
-	if _, err := kubeClient.AdmissionregistrationV1().MutatingWebhookConfigurations().Create(
-		ctx, mutateconfig, metav1.CreateOptions{},
-	); err != nil {
+	webhookConfigs := kubeClient.AdmissionregistrationV1().MutatingWebhookConfigurations()
+	// Try to create configuration when it when missing, update it when it
+	// exists, and retry the lookup if another process wins a create race.
+	existingConfig, err := webhookConfigs.Get(ctx, mutationCfgName, metav1.GetOptions{})
+	if apierrors.IsNotFound(err) {
+		if _, err := webhookConfigs.Create(ctx, mutateconfig, metav1.CreateOptions{}); err == nil {
+			return
+		} else if !apierrors.IsAlreadyExists(err) {
+			panic(err)
+		}
+
+		// Another process created the configuration after the Get call. Fetch it
+		// and continue with the update path.
+		existingConfig, err = webhookConfigs.Get(ctx, mutationCfgName, metav1.GetOptions{})
+	}
+	if err != nil {
+		panic(err)
+	}
+
+	// Preserve metadata managed by Kubernetes or other tooling, while replacing
+	// the webhook specification managed by this program.
+	existingConfig.Webhooks = mutateconfig.Webhooks
+	if _, err := webhookConfigs.Update(ctx, existingConfig, metav1.UpdateOptions{}); err != nil {
 		panic(err)
 	}
 }


### PR DESCRIPTION
* Change `MutatingWebhookConfiguration`'s `namespaceSelector` to only have a `matchExpression` added for the namespace you want to mutate, instead of being applied to basically all namespaces in the cluster by default
* Change `MutatingWebhookConfiguration` so that it can update a deployment safely instead of failing when applied to an existing deployment (you used to have to destroy the previous deployment of user-mutator each time)
* Update README to one PJ gave me
* Update Makefile to be able to input a Helm values file in the `config.env` file provided for the Helm deployment