### PR TITLE
role: scope user-mutator-role to what webhook-server actually calls

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.6.1
+version: 1.6.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/chart/templates/role.yaml
+++ b/chart/templates/role.yaml
@@ -5,10 +5,17 @@ metadata:
   name: user-mutator-role
   namespace: {{ .Release.Namespace }}
 rules:
-- apiGroups: ["apps"]
-  resources: ["deployments"]
-  verbs: ["get", "list", "watch"]
+# Scoped to what webhook-server/main.go actually calls, verified by a repo-wide
+# grep for every CoreV1()/AppsV1() call site. The Deployments API is never
+# called at all (the webhook receives the Deployment object directly in the
+# AdmissionReview payload), so that rule is dropped entirely. secrets/
+# persistentvolumeclaims/configmaps: only `list` is used (FindMatchingResources
+# always lists + regex-matches, even for a plain literal volume source with no
+# capture group; there's no `get`-by-name call site), so `get` is dropped.
+# `list` itself can't be scoped further — Kubernetes RBAC doesn't support
+# resourceNames on the list verb — without a code change to add a get-based
+# fast path for non-regex sources.
 - apiGroups: [""]
-  resources: ["secrets","persistentvolumeclaims", "configmaps"]
-  verbs: ["get", "list"]
+  resources: ["secrets", "persistentvolumeclaims", "configmaps"]
+  verbs: ["list"]
 {{- end }}


### PR DESCRIPTION
## Summary
- Drops the `apps/deployments` rule entirely — `webhook-server` never calls the Deployments API (it receives the Deployment object directly in the AdmissionReview payload), verified via a repo-wide grep of every `CoreV1()`/`AppsV1()` call site.
- Drops `get` on `secrets`/`persistentvolumeclaims`/`configmaps` — `FindMatchingResources` always lists + regex-matches, even for a plain literal volume source with no capture group, so there's no `get`-by-name call site.
- `list` itself is kept as-is (can't be scoped further — Kubernetes RBAC doesn't support `resourceNames` on `list`). Fully closing the secrets-disclosure angle needs a code change to add a `get`-based fast path for non-regex volume sources — out of scope here.
- Chart version `1.6.1` → `1.6.2`.

## Test plan
- [x] Static: `kubectl auth can-i` checks for kept vs. dropped verbs against a scratch ServiceAccount bound to the new Role
- [x] Behavioral: applied the tightened rules to the live `user-mutator-role` in `cddp-stage`, triggered a real admission review by launching an appstore app instance — processed cleanly (LDAP lookup, patch marshalling), no errors, and the resulting instance worked normally
- [x] Reverted the live `cddp-stage` Role back to original after testing; this PR is the durable fix